### PR TITLE
Small wording change and test of pulling

### DIFF
--- a/draft/development_specifics/index.html
+++ b/draft/development_specifics/index.html
@@ -307,8 +307,9 @@
             <li>
                 <h3>mozilla-experimental</h3>
                 <ul>
-                    <li>Preffing off and backing out fixes/features which
-                         are known to not be ready</li>
+                    <li>Preffing off and backing out fixes/features
+                         which the central channel exposes as
+                         problematic with a wider audience.</li>
                     <li>Remaining localizations</li>
                     <li>Landing spot fixes to get the product in a shipping 
                         state</li>


### PR DESCRIPTION
Fix wording to not imply 'unready' features should land on mozilla-central, only that they may be decided to be unready later
