### PR TITLE
Clean up repo/channel naming in overview doc

### DIFF
--- a/draft/development_overview/index.html
+++ b/draft/development_overview/index.html
@@ -138,14 +138,14 @@
           <td class="week" colspan="3">&nbsp;</td>
         </tr>
         <tr>
-          <td class="left" colspan="3">fx-exp</td>
+          <td class="left" colspan="3">mozilla-exp</td>
           <td class="week" colspan="5">&nbsp;</td>
           <td class="firefox5" colspan="6">&nbsp;</td>
           <td class="firefox6" colspan="6">&nbsp;</td>
           <td class="firefox7" colspan="4">&nbsp;</td>
         </tr>
         <tr>
-          <td class="left" colspan="3">fx-beta</td>
+          <td class="left" colspan="3">mozilla-beta</td>
           <td class="week" colspan="10">&nbsp;</td>
           <td class="firefox5" colspan="6">&nbsp;</td>
           <td class="firefox6" colspan="5">&nbsp;</td>
@@ -226,14 +226,14 @@
           <td class="week" colspan="3">&nbsp;</td>
         </tr>
         <tr>
-          <td class="left" colspan="3">fx-exp</td>
+          <td class="left" colspan="3">mozilla-aurora</td>
           <td class="week" colspan="5">&nbsp;</td>
           <td class="firefox5" colspan="6">&nbsp;</td>
           <td class="week" colspan="6">&nbsp;</td>
           <td class="week" colspan="4">&nbsp;</td>
         </tr>
         <tr>
-          <td class="left" colspan="3">fx-beta</td>
+          <td class="left" colspan="3">mozilla-beta</td>
           <td class="week" colspan="10">&nbsp;</td>
           <td class="firefox5" colspan="6">&nbsp;</td>
           <td class="week" colspan="5">&nbsp;</td>

--- a/draft/development_overview/index.html
+++ b/draft/development_overview/index.html
@@ -399,7 +399,7 @@
           <td class="firefox8" colspan="6">&nbsp;</td>
         </tr>
         <tr>
-          <td class="left" colspan="3">fx-experimental</td>
+          <td class="left" colspan="3">mozilla-aurora</td>
           <td class="week" colspan="2">&nbsp;</td>
           <td class="firefox5" colspan="6">&nbsp;</td>
           <td class="firefox6" colspan="6">&nbsp;</td>
@@ -407,7 +407,7 @@
           <td class="firefox8" colspan="1">&nbsp;</td>
         </tr>
         <tr>
-          <td class="left" colspan="3">fx-beta</td>
+          <td class="left" colspan="3">mozilla-beta</td>
           <td class="week" colspan="7">&nbsp;</td>
           <td class="firefox5" colspan="6">&nbsp;</td>
           <td class="firefox6" colspan="6">&nbsp;</td>

--- a/draft/development_overview/index.html
+++ b/draft/development_overview/index.html
@@ -454,7 +454,7 @@
         <h2>Security Releases</h2>
         <p>This proposal makes security updates occur along with Firefox releases, meaning we'll no longer be maintaining old branches. Having security branches for each major update is untenable if we release as often as we aim to.</p>
         <h2>Silent Updates</h2>
-        <p>This proposal also requires changes to our software update behavior to make them happen more automatically in the background and interrupt the user less often. Otherwise, we will disrupt fx-beta users too much. There will also need to be an option for users to completely disable automatic updates, so that they can manage their own upgrade process.</p>
+        <p>This proposal also requires changes to our software update behavior to make them happen more automatically in the background and interrupt the user less often. Otherwise, we will disrupt mozilla-beta users too much. There will also need to be an option for users to completely disable automatic updates, so that they can manage their own upgrade process.</p>
         <h2>Extension Compatibility</h2>
         <p>Extension compatibility is the trickiest part of the transition. In particular, it's not what the policy should be when a user has extensions that are incompatible with a new Firefox release. Each release will have at least 12 weeks to identify extensions that are no longer working, but this issue will be complicated.</p>
         <h2>What about Firefox 4.0.x?</h2>

--- a/draft/development_overview/index.html
+++ b/draft/development_overview/index.html
@@ -95,9 +95,9 @@
       </div>      
       <img class="diagram" src="img/sequence.png">
       <div class="body-text">
-        <p>The four channels available are: mozilla-central (or "nightly"), mozilla-aurora, firefox-beta, and Firefox (release) <font color=red><i>[these names are placeholders]</i></font>. The nightly channel gets new features as soon as they are ready, but it has the lowest stability of the four channels. The UI might change each day, and websites might not work at times. The mozilla-aurora channel gets new features at regular intervals, but some of them might be disabled if it looks like they need more work. The beta channel receives only new features that are slated for the next Firefox release.</p>
+        <p>The four channels available are: mozilla-central (or "nightly"), mozilla-aurora, mozilla-beta, and Firefox (release) <font color=red><i>[these names are placeholders]</i></font>. The nightly channel gets new features as soon as they are ready, but it has the lowest stability of the four channels. The UI might change each day, and websites might not work at times. The mozilla-aurora channel gets new features at regular intervals, but some of them might be disabled if it looks like they need more work. The beta channel receives only new features that are slated for the next Firefox release.</p>
 
-        <p>Each release channel is backed by a Mercurial repository containing a distinct copy of the Firefox source code.As a set of changes progresses through the repositories, features that aren't quite ready are disabled. <b>New features are never directly added to the mozilla-aurora or firefox-beta channels.</b> Features that end up disabled or miss the scheduled transition to the experimental channel can be pulled again the next time the schedule permits. This policy does allow for features that take a long time to develop. It's just that they'll be present only on mozilla-central until they're ready. The number of users on each channel grows by roughly 10x as the changes make their way through the release process, and features on each channel require an accompanying improvement in stability.</p>
+        <p>Each release channel is backed by a Mercurial repository containing a distinct copy of the Firefox source code.As a set of changes progresses through the repositories, features that aren't quite ready are disabled. <b>New features are never directly added to the mozilla-aurora or mozilla-beta channels.</b> Features that end up disabled or miss the scheduled transition to the experimental channel can be pulled again the next time the schedule permits. This policy does allow for features that take a long time to develop. It's just that they'll be present only on mozilla-central until they're ready. The number of users on each channel grows by roughly 10x as the changes make their way through the release process, and features on each channel require an accompanying improvement in stability.</p>
       </div>
       <img class="diagram" src="channels.png">
       <div class="body-text">
@@ -184,7 +184,7 @@
       </table>
       <div class="body-text">
         <p>In the diagram above, the blue bars represent one set of changes progressing through each channel. Simultaneously, work continues on the mozilla-central repository. Some features might need three cycles (18 weeks) on mozilla-central before they're ready. Since mozilla-central will be pulled into the mozilla-aurora channel at week 6 and week 12, such <b>features will need to have a mechanism allowing them to be easily disabled</b>. Essentially, it needs to be easy to get the code on mozilla-central into a shippable state by disabling new code.</p>
-        <p>The mozilla-central, mozilla-aurora, and firefox-beta channels receive frequent updates so changes to the program can be validated before appearing in the general release. The release channel receives updates from the beta channel periodically.</p>
+        <p>The mozilla-central, mozilla-aurora, and mozilla-beta channels receive frequent updates so changes to the program can be validated before appearing in the general release. The release channel receives updates from the beta channel periodically.</p>
         <p>Under this system, there is a choice to ship a general Firefox release at week 16 and every six weeks thereafter. That doesn't mean a release will happen every six weeks, but the option will be available.</p>
         <h2>Moving work from one channel to another</h2>
         <p>New code migrates from one repository to another on a fixed schedule. For example, in the diagram above, new code from mozilla-central arrives in week 6, 12, and 18. It might seem expedient to land new features from mozilla-central as soon as they are "ready", but such a pattern would introduce too many variables into stability measurements. The one exception to this schedule is that unscheduled releases may be required for <b>critical security and stability</b> issues.</p>
@@ -352,13 +352,13 @@
         <p class="l10ncode">The majority of localization teams finish their work on the product.</p>
         <h2>Week 11</h2>
         <p>Release management makes a Go/No Go decision on whether the mozilla-aurora channel can be pulled.</p>
-        <p>If the decision is made to Go, a repository pull from mozilla-aurora to firefox-beta is done.</p>
+        <p>If the decision is made to Go, a repository pull from mozilla-aurora to mozilla-beta is done.</p>
         <p class="l10ncode">Only minor changes to localizations are still taken.</p>
         <h2>Week 12-13</h2>
-        <p>Release management, QA, and engineering work to stabilize any issues that arise as the code is exposed to the firefox-beta channel's wider audience.</p>
+        <p>Release management, QA, and engineering work to stabilize any issues that arise as the code is exposed to the mozilla-beta channel's wider audience.</p>
         <p>Security patches from the shadow security repository are landed. <font color="red"><b>n.b.: exact timing and mechanics undecided.</b></font></p>
         <h2>Week 14</h2>
-        <p>Release management makes a Go/No Go to make release the contents of the firefox-beta channel to the general audience.</p>
+        <p>Release management makes a Go/No Go to make release the contents of the mozilla-beta channel to the general audience.</p>
         <h2>Week 16</h2>
         <p>If there's a release to do, it happens during this week.</p>
         <p class="l10ncode">Localizations that are in beta are not pulled into the release channel.</p>
@@ -449,7 +449,7 @@
       <div class="body-text">
         <p>The goal of this proposed initial release pattern is to limit patch build up in mozilla-central, as well as establish a regular six week cadence for release go/no-go decisions thereafter.</p>
         <h2>Channel Update System</h2>
-        <p>For this plan to work at all, we need establish the mozilla-aurora and firefox-beta channels. The plan is to seed them with roughly 500K users on the experimental channel, and about 1.5 million people on the firefox-beta channel. We'll use the current Firefox 4 beta audience for this. Once the channels are available as a choice in the general Firefox release, their audiences should grow.</p>
+        <p>For this plan to work at all, we need establish the mozilla-aurora and mozilla-beta channels. The plan is to seed them with roughly 500K users on the experimental channel, and about 1.5 million people on the mozilla-beta channel. We'll use the current Firefox 4 beta audience for this. Once the channels are available as a choice in the general Firefox release, their audiences should grow.</p>
         <p>There's also a dependency on the updater code and UI needed for this system in the first place, and it will be difficult to get it done in time.</p>
         <h2>Security Releases</h2>
         <p>This proposal makes security updates occur along with Firefox releases, meaning we'll no longer be maintaining old branches. Having security branches for each major update is untenable if we release as often as we aim to.</p>

--- a/draft/development_overview/index.html
+++ b/draft/development_overview/index.html
@@ -95,9 +95,9 @@
       </div>      
       <img class="diagram" src="img/sequence.png">
       <div class="body-text">
-        <p>The four channels available are: mozilla-central (or "nightly"), firefox-experimental, firefox-beta, and Firefox (release) <font color=red><i>[these names are placeholders]</i></font>. The nightly channel gets new features as soon as they are ready, but it has the lowest stability of the four channels. The UI might change each day, and websites might not work at times. The firefox-experimental channel gets new features at regular intervals, but some of them might be disabled if it looks like they need more work. The beta channel receives only new features that are slated for the next Firefox release.</p>
+        <p>The four channels available are: mozilla-central (or "nightly"), mozilla-aurora, firefox-beta, and Firefox (release) <font color=red><i>[these names are placeholders]</i></font>. The nightly channel gets new features as soon as they are ready, but it has the lowest stability of the four channels. The UI might change each day, and websites might not work at times. The mozilla-aurora channel gets new features at regular intervals, but some of them might be disabled if it looks like they need more work. The beta channel receives only new features that are slated for the next Firefox release.</p>
 
-        <p>Each release channel is backed by a Mercurial repository containing a distinct copy of the Firefox source code.As a set of changes progresses through the repositories, features that aren't quite ready are disabled. <b>New features are never directly added to the firefox-experimental or firefox-beta channels.</b> Features that end up disabled or miss the scheduled transition to the experimental channel can be pulled again the next time the schedule permits. This policy does allow for features that take a long time to develop. It's just that they'll be present only on mozilla-central until they're ready. The number of users on each channel grows by roughly 10x as the changes make their way through the release process, and features on each channel require an accompanying improvement in stability.</p>
+        <p>Each release channel is backed by a Mercurial repository containing a distinct copy of the Firefox source code.As a set of changes progresses through the repositories, features that aren't quite ready are disabled. <b>New features are never directly added to the mozilla-aurora or firefox-beta channels.</b> Features that end up disabled or miss the scheduled transition to the experimental channel can be pulled again the next time the schedule permits. This policy does allow for features that take a long time to develop. It's just that they'll be present only on mozilla-central until they're ready. The number of users on each channel grows by roughly 10x as the changes make their way through the release process, and features on each channel require an accompanying improvement in stability.</p>
       </div>
       <img class="diagram" src="channels.png">
       <div class="body-text">
@@ -183,8 +183,8 @@
         </tr>
       </table>
       <div class="body-text">
-        <p>In the diagram above, the blue bars represent one set of changes progressing through each channel. Simultaneously, work continues on the mozilla-central repository. Some features might need three cycles (18 weeks) on mozilla-central before they're ready. Since mozilla-central will be pulled into the firefox-experimental channel at week 6 and week 12, such <b>features will need to have a mechanism allowing them to be easily disabled</b>. Essentially, it needs to be easy to get the code on mozilla-central into a shippable state by disabling new code.</p>
-        <p>The mozilla-central, firefox-experimental, and firefox-beta channels receive frequent updates so changes to the program can be validated before appearing in the general release. The release channel receives updates from the beta channel periodically.</p>
+        <p>In the diagram above, the blue bars represent one set of changes progressing through each channel. Simultaneously, work continues on the mozilla-central repository. Some features might need three cycles (18 weeks) on mozilla-central before they're ready. Since mozilla-central will be pulled into the mozilla-aurora channel at week 6 and week 12, such <b>features will need to have a mechanism allowing them to be easily disabled</b>. Essentially, it needs to be easy to get the code on mozilla-central into a shippable state by disabling new code.</p>
+        <p>The mozilla-central, mozilla-aurora, and firefox-beta channels receive frequent updates so changes to the program can be validated before appearing in the general release. The release channel receives updates from the beta channel periodically.</p>
         <p>Under this system, there is a choice to ship a general Firefox release at week 16 and every six weeks thereafter. That doesn't mean a release will happen every six weeks, but the option will be available.</p>
         <h2>Moving work from one channel to another</h2>
         <p>New code migrates from one repository to another on a fixed schedule. For example, in the diagram above, new code from mozilla-central arrives in week 6, 12, and 18. It might seem expedient to land new features from mozilla-central as soon as they are "ready", but such a pattern would introduce too many variables into stability measurements. The one exception to this schedule is that unscheduled releases may be required for <b>critical security and stability</b> issues.</p>
@@ -344,15 +344,15 @@
         <p>Feature development on mozilla-central.</p>
         <p class="l10ncode">The feature development is tracked by a core of the localization community, giving feedback about l12y early in the development process.</p>
         <h2>Week 6</h2>
-        <p>The code on mozilla-central is pulled to the firefox-experimental channel.</p>
+        <p>The code on mozilla-central is pulled to the mozilla-aurora channel.</p>
         <p>Extension developers can rely on the APIs they see here, with the exception of new APIs that might end up disabled. The front end XUL might change for stability reasons, but not in major ways. Again, XUL related to new features may not be available if those features end up getting disabled.</p>
         <p>en-US strings are frozen.</p>
         <h2>Week 7-10</h2>
         <p>Release management, QA, and engineering work to stabilize or disable new features.</p>
         <p class="l10ncode">The majority of localization teams finish their work on the product.</p>
         <h2>Week 11</h2>
-        <p>Release management makes a Go/No Go decision on whether the firefox-experimental channel can be pulled.</p>
-        <p>If the decision is made to Go, a repository pull from firefox-experimental to firefox-beta is done.</p>
+        <p>Release management makes a Go/No Go decision on whether the mozilla-aurora channel can be pulled.</p>
+        <p>If the decision is made to Go, a repository pull from mozilla-aurora to firefox-beta is done.</p>
         <p class="l10ncode">Only minor changes to localizations are still taken.</p>
         <h2>Week 12-13</h2>
         <p>Release management, QA, and engineering work to stabilize any issues that arise as the code is exposed to the firefox-beta channel's wider audience.</p>
@@ -449,7 +449,7 @@
       <div class="body-text">
         <p>The goal of this proposed initial release pattern is to limit patch build up in mozilla-central, as well as establish a regular six week cadence for release go/no-go decisions thereafter.</p>
         <h2>Channel Update System</h2>
-        <p>For this plan to work at all, we need establish the firefox-experimental and firefox-beta channels. The plan is to seed them with roughly 500K users on the experimental channel, and about 1.5 million people on the firefox-beta channel. We'll use the current Firefox 4 beta audience for this. Once the channels are available as a choice in the general Firefox release, their audiences should grow.</p>
+        <p>For this plan to work at all, we need establish the mozilla-aurora and firefox-beta channels. The plan is to seed them with roughly 500K users on the experimental channel, and about 1.5 million people on the firefox-beta channel. We'll use the current Firefox 4 beta audience for this. Once the channels are available as a choice in the general Firefox release, their audiences should grow.</p>
         <p>There's also a dependency on the updater code and UI needed for this system in the first place, and it will be difficult to get it done in time.</p>
         <h2>Security Releases</h2>
         <p>This proposal makes security updates occur along with Firefox releases, meaning we'll no longer be maintaining old branches. Having security branches for each major update is untenable if we release as often as we aim to.</p>

--- a/draft/development_specifics/index.html
+++ b/draft/development_specifics/index.html
@@ -177,6 +177,10 @@
                         <td>nightly</td>
                     </tr>
                     <tr>
+                        <th>Signed</th>
+                        <td>No</td>
+                    </tr>
+                    <tr>
                         <th>Branded</th>
                         <td>Not branded as Firefox, uses new "Nightly" icon</td>
                     </tr>
@@ -207,6 +211,10 @@
                         <td>nightly</td>
                     </tr>
                     <tr>
+                        <th>Signed</th>
+                        <td>No</td>
+                    </tr>
+                    <tr>
                         <th>Branded</th>
                         <td>Not branded as Firefox, uses new "Aurora" icon</td>
                     </tr>
@@ -232,6 +240,10 @@
                     <tr>
                         <th>Anticipated Update Rate</th>
                         <td>weekly (highly dependent on found issues)</td>
+                    </tr>
+                    <tr>
+                        <th>Signed</th>
+                        <td>Yes, same as release</td>
                     </tr>
                     <tr>
                         <th>Branded</th>
@@ -260,6 +272,10 @@
                     <tr>
                         <th>Anticipated Update Rate</th>
                         <td>6-12 weeks</td>
+                    </tr>
+                    <tr>
+                        <th>Signed</th>
+                        <td>Yes</td>
                     </tr>
                     <tr>
                         <th>Branded</th>


### PR DESCRIPTION
Clean up repo/channel naming in overview doc
